### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://binsel.visualstudio.com/360b41f1-f040-4f59-b10b-5ef9349c2f0a/711d6ea9-c48c-45e2-b035-fc238bab84c9/_apis/work/boardbadge/65fd5ab4-9afa-4ac4-b969-802b1e9eb2cd)](https://binsel.visualstudio.com/360b41f1-f040-4f59-b10b-5ef9349c2f0a/_boards/board/t/711d6ea9-c48c-45e2-b035-fc238bab84c9/Microsoft.RequirementCategory)
 # hello-world
 My name is Burhan


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://binsel.visualstudio.com/360b41f1-f040-4f59-b10b-5ef9349c2f0a/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.